### PR TITLE
fix: regex as per latest exported chat

### DIFF
--- a/whatsapp_chat_parser.py
+++ b/whatsapp_chat_parser.py
@@ -9,11 +9,16 @@
 from datetime import datetime
 import re
 
-REGEX_DATE = """^(\u200e){0,1}\[[0-9\/]+(, )[0-9:]+\]"""
-REGEX_CONTACT = """^(\u200e){0,1}\[[0-9\/]+(, )[0-9:]+\](.+?)(: )"""
-REGEX_MESSAGE = """^(\u200e){0,1}\[[0-9\/]+(, )[0-9:]+\](.)+(: )(.+)"""
+# *For older versions of Whatsapp Export*
+# REGEX_DATE = """^(\u200e){0,1}\[[0-9\/]+(, )[0-9:]+\]"""
+# REGEX_CONTACT = """^(\u200e){0,1}\[[0-9\/]+(, )[0-9:]+\](.+?)(: )"""
+# REGEX_MESSAGE = """^(\u200e){0,1}\[[0-9\/]+(, )[0-9:]+\](.)+(: )(.+)"""
 
-DATE_FORMAT = '[%d/%m/%Y, %H:%M:%S]'
+REGEX_DATE = """^(\u200e){0,1}\[[0-9\/]+(, )[0-9:]+ [a-zA-Z]{2}\]"""
+REGEX_CONTACT = """^(\u200e){0,1}\[[0-9\/]+(, )[0-9:]+ [a-zA-Z]{2}\](.+?)(: )"""
+REGEX_MESSAGE = """^(\u200e){0,1}\[[0-9\/]+(, )[0-9:]+ [a-zA-Z]{2}\](.)+(: )(.+)"""
+
+DATE_FORMAT = '[%d/%m/%y, %I:%M:%S %p]' 
 
 def __parse_timestamp(s, date_format):
     return datetime.strptime(s, date_format)


### PR DESCRIPTION
the following regex format was not working in case of the new WhatsApp chat export

Example of new chat export:
[11/01/22, 4:19:15 PM] ‪+91 80--0 19942‬: ‎Messages and calls are end-to-end encrypted. No one outside of this chat, not even WhatsApp, can read or listen to them.
‎[11/01/22, 4:19:15 PM] Mycorporation: V--- SEGA RS.pdf • ‎14 pages ‎<attached: 00000002-RS.pdf>
[11/01/22, 4:19:15 PM] Mycorporation: This is car loan statement.
‎[11/01/22, 4:19:15 PM] Mycorporation: 42821-704405.pdf • ‎2 pages ‎<attached: 00000004-42821-704405.pdf>
[11/01/22, 4:19:15 PM] Mycorporation: Apr 20 bills
‎[11/01/22, 4:19:15 PM] Mycorporation: 42821-728608.pdf • ‎2 pages ‎<attached: 00000006-42821-728608.pdf>